### PR TITLE
fix cont index to cut words of vocabulary

### DIFF
--- a/downstream/TextSGC/remove_words.py
+++ b/downstream/TextSGC/remove_words.py
@@ -80,7 +80,7 @@ vocab, count = zip(*word_freq.most_common())
 if dataset == "mr":
     cutoff = -1
 else:
-    cutoff = count.index(5)
+    cutoff = count.index(4)
 
 vocab = set(vocab[:cutoff])
 


### PR DESCRIPTION
Hello, first of all I would like to say that this is an amazing work!
I have been testing this work for the text (documents) datasets.

I figure out that the vocabulary size of your approach in the texts datasets differ from the approach of TextGCN. For example in dataset R8 when "wc -l data/corpus/R8_vocab.txt" the vocabulary size is 6791words, but in the paper of TextGCN the size is 7688 words.

I fix this changing the index of cutoff from 5 to 4 in "remove_words.py"