### PR TITLE
Bugfix: reference cuda arg in call to load_reddit_data

### DIFF
--- a/reddit.py
+++ b/reddit.py
@@ -35,7 +35,7 @@ args.cuda = not args.no_cuda and torch.cuda.is_available()
 
 set_seed(args.seed, args.cuda)
 
-adj, train_adj, features, labels, idx_train, idx_val, idx_test = load_reddit_data(args.normalization)
+adj, train_adj, features, labels, idx_train, idx_val, idx_test = load_reddit_data(args.normalization, cuda=args.cuda)
 print("Finished data loading.")
 
 model = SGC(features.size(1), labels.max().item()+1)


### PR DESCRIPTION
The cuda argument is always True within the load_reddit_data function, leading to a torch error if cuda is not available. This change allows the user to run the reddit dataset experiments without cuda.

Test plan:

Running reddit evaluation without cuda produces this error:
```
python reddit.py --inductive --test
Traceback (most recent call last):
  File "reddit.py", line 38, in <module>
    adj, train_adj, features, labels, idx_train, idx_val, idx_test = load_reddit_data(args.normalization)
  File "/Users/ktb477/SGC/utils.py", line 127, in load_reddit_data
    adj = adj.cuda()
  File "/Users/ktb477/.pyenv/versions/SGC/lib/python3.8/site-packages/torch/cuda/__init__.py", line 164, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

With the proposed change:
```
python reddit.py --inductive --test
Finished data loading.
Total Time: 22.9538s, Test F1: 0.9501
```